### PR TITLE
Warnfix

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -255,7 +255,6 @@ WIFI_DRIVER_FW_PATH_PARAM        := "/sys/module/dhd/parameters/firmware_path"
 WIFI_DRIVER_FW_PATH_STA          := "/vendor/etc/wifi/bcmdhd_sta.bin"
 WIFI_DRIVER_FW_PATH_AP           := "/vendor/etc/wifi/bcmdhd_apsta.bin"
 #WIFI_BAND                        := 802_11_ABG
-WPA_SUPPLICANT_USE_HIDL          := true
 
 # WiFi Configs
 PRODUCT_COPY_FILES += \

--- a/shims/libbauthtzcommon/libbauthtzcommon.c
+++ b/shims/libbauthtzcommon/libbauthtzcommon.c
@@ -19,7 +19,7 @@
 
 #include <cutils/log.h>
 
-int BAuth_Hat_OP(void *dest, int dummy)
+int BAuth_Hat_OP(__unused void *dest, __unused int dummy)
 {
     ALOGV("SHIM: hijacking %s!", __func__);
 


### PR DESCRIPTION
mark parameters as unused in shims/libbauthtzcommon/libbauthtzcommon.c
remove duplicated WPA_SUPPLICANT_USE_HIDL